### PR TITLE
0.8.95 changes

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -3,7 +3,8 @@ Copyright © Michael Cowgill (CHurchOrganist) 2020
 adds circuit connections to mining drills
 radar visualisation to the Yuoki Radar
 logistic filters to storage chests
-and adds buffer chests to the mod
+adds buffer chests to the mod and
+introduces vanilla comptaibilty for Yuoki prod modules
 Licenced with the MIT licence--]]
 
 --Call buffer chest initialisation script
@@ -42,3 +43,11 @@ data.raw.radar.yi_radar.radius_minimap_visualisation_color = radar_visualisation
 -- add logistic filter to y-rare-chest-log and y-rare-m1bunker-log
 data.raw["logistic-container"]["y-rare-chest-log"].logistic_slots_count = 1
 data.raw["logistic-container"]["y-rare-m1bunker-log"].logistic_slots_count = 1
+
+-- make Yuoki productivity modules obey same rules as vanilla if configured as such.
+
+--read productivity module setting and call script if true
+local prod_mod = settings.startup["yuoki-prod-mod-behaviour"].value
+if prod_mod == true then
+    require("prototypes.y_prodmod_as_vanilla")
+end

--- a/data.lua
+++ b/data.lua
@@ -74,6 +74,10 @@ require("prototypes.objects._tiles")
 require("prototypes.item.y_stacksizes")
 --require("y_config")
 
-data.raw["character"]["character"].inventory_size = 120
---data.raw["character"]["character"].build_distance = 10000
---data.raw["character"]["character"].reach_distance = 10000
+--add list of Yuoki intermeidate producrs to vanilla intermediates (thank you Codec)
+require ("prototypes.y_intermediates_list")
+
+--load configurable character options from settings file
+data.raw["character"]["character"].inventory_size = settings.startup["yuoki-inventory-size"].value
+data.raw["character"]["character"].build_distance = settings.startup["yuoki-player-reach"].value
+data.raw["character"]["character"].reach_distance = settings.startup["yuoki-player-reach"].value

--- a/prototypes/y_intermediates_list.lua
+++ b/prototypes/y_intermediates_list.lua
@@ -1,0 +1,68 @@
+--[[Yuoki intermediates script
+Copyright joshrick (Codec) © August 2020
+adds Yuoki intermediate products to the vanilla intermediates list--]]
+local productivity_item_list=
+                      { "y_slag_brick_burn_recipe",
+                        "y_slag_brick_recipe",
+                        "y_slag_granulate_recipe",
+                        "y_hps_steel_recipe",
+                        "y_hps_purecopper_recipe",
+                        "y_hps_pureiron_recipe",
+                        "y-basic-st2-mf-recipe",
+                        "y-chip2-recipe",
+                        "yi_magnetron_recipe",
+                        "y_ammo_plasma_recipe",
+                        "y-battery-single-use3-recipe",
+                        "y_blocked_capa_recipe",
+                        "y-crystal-cnd-recipe",
+                        "y-quantrinum-recipe",
+                        "y-fuel-reactor-recipe",
+                        "y-infused-mud-recipe",
+                        "y-infused-uca2-recipe",
+                        "y-mixfuel-load-recipe",
+                        "y-wooden-brikett-packed-recipe",
+                        "y-pure-copper-recipe",
+                        "y-pure-iron-recipe",
+                        "y-refined-copper",
+                        "y-refined-iron",
+                        "y-wash-dirt-recipe",
+                        "y-smelt-crush-res1-recipe",
+                        "y-smelt-crush-res2-recipe",
+                        "y_quantrinum_infusion_recipe",
+                        "y_structure_element_recipe",
+                        "y-bluegear-recipe",
+                        "y_structure_vessel_recipe",
+                        "y-basic-st1-mf-recipe",
+                        "y_chip_plate_recipe",
+                        "y_dotzetron_recipe",
+                        "y_structure_electric_recipe",
+                        "y-heat-pipe-recipe",
+                        "y-heat-pipe-recipe",
+                        "y-conductive-coil-1-recipe",
+                        "y-conductive-wire-1_recipe",
+                        "y-crush-unicomp-raw-recipe",
+                        "y-crush-fuel-raw-recipe",
+                        "y_slag_granulate_recipe",
+                        "y_steinmehl_recipe",
+                        "y-coaldust-recipe",
+                        "y_granulate_wood_recipe",
+                        "y-unicomp-raw-recipe",
+                        "y-raw-fuelnium-recipe",
+                        "y-bullet-case-recipe",
+                        "y_ammo_case_recipe",
+                        "yi_graphite_recipe",
+                        "y_data_crystal_recipe"
+                      }
+
+for _, module in pairs(data.raw.module) do
+  if module.effect and module.limitation then
+    for effect_name in pairs(module.effect) do
+      if effect_name == "productivity"then
+    for _, item in pairs( productivity_item_list) do
+                table.insert(module.limitation,    item)
+    end
+        break
+      end
+    end
+  end
+end

--- a/prototypes/y_prodmod_as_vanilla.lua
+++ b/prototypes/y_prodmod_as_vanilla.lua
@@ -1,0 +1,12 @@
+--[[y_prodmod_as_vanilla
+Sets Yuoki Productivity modules to behave like vanilla
+Copyright © Michael Cowgill (ChurchOrganist) August 2020]]
+
+--read intermediates list from data.raw
+local intermediates_list = data.raw.module["productivity-module"].limitation
+
+--apply intermediates list to yuoki productivity modules
+data.raw.module["y-pink-module-1"].limitation = intermediates_list
+data.raw.module["y-pink-module-2"].limitation = intermediates_list
+data.raw.module["y-pink-module-3"].limitation = intermediates_list
+data.raw.module.y_modul_science.limitation = intermediates_list

--- a/settings.lua
+++ b/settings.lua
@@ -1,0 +1,27 @@
+data:extend({
+    {
+        type = "bool-setting",
+        name = "yuoki-prod-mod-behaviour",
+        setting_type = "startup",
+        default_value = true,
+        order = "a"
+    },
+    {
+        type = "int-setting",
+        name = "yuoki-inventory-size",
+        setting_type = "startup",
+        minimum_value = 80,
+        maximum_value = 150,
+        default_value = 80,
+        order = "b"
+    },
+    {
+        type = "int-setting",
+        name = "yuoki-player-reach",
+        setting_type = "startup",
+        minimum_value = 10,
+        maximum_value = 32,
+        default_value = 10,
+        order = "c"
+    }
+})


### PR DESCRIPTION
Adds settings for Yuoki Productivity module behaviour, and player inventory and reach.
List of Yuoki intermediate products added to vanilla list.
Yuoki productivity modules behave as vanilla unless configured not to.