### PR TITLE
Add productivity to the allowed_effects for the crusher and washer.

### DIFF
--- a/prototypes/entity/e_advmachinery.lua
+++ b/prototypes/entity/e_advmachinery.lua
@@ -67,7 +67,7 @@ data:extend(
 		{
 			module_slots = 2
 		},
-		allowed_effects = {"consumption", "speed", "pollution"},
+		allowed_effects = {"consumption", "speed", "productivity", "pollution"},
 	},
 
 	{

--- a/prototypes/entity/y_entities.lua
+++ b/prototypes/entity/y_entities.lua
@@ -134,7 +134,7 @@ data:extend(
 		{
 			module_slots = 2
 		},
-		allowed_effects = {"consumption", "speed", "pollution"},
+		allowed_effects = {"consumption", "speed", "productivity", "pollution"},
 	},
 	
 	-- Outpost Mining Drill


### PR DESCRIPTION
Add productivity to the allowed_effects so you can put productivity modules in the washer and crusher with allowed recipes.